### PR TITLE
Stop abuse of the lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **How to use**
 
 You can create as many locks as you want. It will be generated based on how many random numbers are provided to the **createSafe** function;
-Also, you shall only provide numbers **between 0 and 99**, it will be impossible to **finish the minigame properly!**
+Also, you shall only provide numbers **between 0 and 99**, otherwise it will be impossible to **finish the minigame properly!**
 `````lua
 local res = exports["pd-safe"]:createSafe({math.random(0,99)})
 `````

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **How to use**
 
 You can create as many locks as you want. It will be generated based on how many random numbers are provided to the **createSafe** function;
-Also, you shall only provide numbers **between 0 and 99**, otherwise it will be impossible to **finish the minigame properly!**
+Also, you shall only provide numbers **between 0 and 99**, it will be impossible to **finish the minigame properly!**
 `````lua
 local res = exports["pd-safe"]:createSafe({math.random(0,99)})
 `````


### PR DESCRIPTION
This commit requires the lock to be rotated at least 25 times before it will release the tumbler. If you go over the correct pin in the wrong direction, it will reset this counter. stopping abuse and being more like how the locks actually work